### PR TITLE
add debug flag to `nbprocess_filter`

### DIFF
--- a/nbprocess/cli.py
+++ b/nbprocess/cli.py
@@ -93,7 +93,7 @@ def _zero_pad(n, nlen=3): return str(n + (10**nlen))[1:]
 @call_parse
 def nbprocess_filter(
     nb_txt:str=None,  # Notebook text (uses stdin if not provided)
-    debug:bool=False # Debug mode that writes json into .nbprocess_filter_debug/
+    debug:bool=False # Debug mode that writes json into _nbprocess_filter_debug/
 ):
     "A notebook filter for quarto"
     os.environ["IN_TEST"] = "1"

--- a/nbprocess/cli.py
+++ b/nbprocess/cli.py
@@ -108,7 +108,7 @@ def nbprocess_filter(
     if debug: 
         outdir = Path('_nbprocess_filter_debug')
         outdir.mkdir(exist_ok=True)
-        num = max(outdir.ls().attrgot('name').map(_get_num).map(int)) + 1
+        num = max(outdir.ls().attrgot('name').map(_get_num).map(int) + [0]) + 1
         (outdir/f'file_out_{_zero_pad(num)}.ipynb').write_text(res)
         (outdir/f'file_in_{_zero_pad(num)}.ipynb').write_text(nb_txt)
     else: return res

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -155,6 +155,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11f37097-208d-4613-8c2a-6b6422487722",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|export\n",
+    "_re_file_in = re.compile(r'file_in_(\\d{3})\\.ipynb')\n",
+    "def _get_num(f): \n",
+    "    match = _re_file_in.findall(f)\n",
+    "    return match[0] if match else 0\n",
+    "def _zero_pad(n, nlen=3): return str(n + (10**nlen))[1:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0ce7675e",
    "metadata": {},
    "outputs": [],
@@ -162,7 +177,8 @@
     "#|export\n",
     "@call_parse\n",
     "def nbprocess_filter(\n",
-    "    nb_txt:str=None  # Notebook text (uses stdin if not provided)\n",
+    "    nb_txt:str=None,  # Notebook text (uses stdin if not provided)\n",
+    "    debug:bool=False # Debug mode that writes json into .nbprocess_filter_debug/\n",
     "):\n",
     "    \"A notebook filter for quarto\"\n",
     "    os.environ[\"IN_TEST\"] = \"1\"\n",
@@ -174,6 +190,12 @@
     "    res = nb2str(nb)\n",
     "    del os.environ[\"IN_TEST\"]\n",
     "    if printit: print(res, flush=True)\n",
+    "    if debug: \n",
+    "        outdir = Path('_nbprocess_filter_debug')\n",
+    "        outdir.mkdir(exist_ok=True)\n",
+    "        num = max(outdir.ls().attrgot('name').map(_get_num).map(int)) + 1\n",
+    "        (outdir/f'file_out_{_zero_pad(num)}.ipynb').write_text(res)\n",
+    "        (outdir/f'file_in_{_zero_pad(num)}.ipynb').write_text(nb_txt)\n",
     "    else: return res"
    ]
   },

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -178,7 +178,7 @@
     "@call_parse\n",
     "def nbprocess_filter(\n",
     "    nb_txt:str=None,  # Notebook text (uses stdin if not provided)\n",
-    "    debug:bool=False # Debug mode that writes json into .nbprocess_filter_debug/\n",
+    "    debug:bool=False # Debug mode that writes json into _nbprocess_filter_debug/\n",
     "):\n",
     "    \"A notebook filter for quarto\"\n",
     "    os.environ[\"IN_TEST\"] = \"1\"\n",

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -193,7 +193,7 @@
     "    if debug: \n",
     "        outdir = Path('_nbprocess_filter_debug')\n",
     "        outdir.mkdir(exist_ok=True)\n",
-    "        num = max(outdir.ls().attrgot('name').map(_get_num).map(int)) + 1\n",
+    "        num = max(outdir.ls().attrgot('name').map(_get_num).map(int) + [0]) + 1\n",
     "        (outdir/f'file_out_{_zero_pad(num)}.ipynb').write_text(res)\n",
     "        (outdir/f'file_in_{_zero_pad(num)}.ipynb').write_text(nb_txt)\n",
     "    else: return res"


### PR DESCRIPTION
In this PR I add a `--debug` flag to `npbrocess_filter` that will write the input and output notebooks into to the directory `_nbprocess_filter_debug`

I'm using this to debug #37 