### PR TITLE
Fix error in nb_quarto moving README.md from docs

### DIFF
--- a/nbprocess/cli.py
+++ b/nbprocess/cli.py
@@ -288,8 +288,8 @@ def nbprocess_quarto(
     
     if (tmp_doc_path/'README.md').exists():
         (cfg_path/'README.md').unlink(missing_ok=True)
-        shutil.move(tmp_doc_path/'README.md', cfg_path) # README.md is temporarily in the nbs/docs folder
+        shutil.move((tmp_doc_path/'README.md').as_posix(), cfg_path.as_posix()) # README.md is temporarily in the nbs/docs folder
     
     if tmp_doc_path.parent != cfg_path: # move docs folder to root of repo if it doesn't exist there
         shutil.rmtree(doc_path, ignore_errors=True)
-        shutil.move(tmp_doc_path, cfg_path)
+        shutil.move(tmp_doc_path.as_posix(), cfg_path.as_posix())

--- a/nbs/10_cli.ipynb
+++ b/nbs/10_cli.ipynb
@@ -487,11 +487,11 @@
     "    \n",
     "    if (tmp_doc_path/'README.md').exists():\n",
     "        (cfg_path/'README.md').unlink(missing_ok=True)\n",
-    "        shutil.move(tmp_doc_path/'README.md', cfg_path) # README.md is temporarily in the nbs/docs folder\n",
+    "        shutil.move((tmp_doc_path/'README.md').as_posix(), cfg_path.as_posix()) # README.md is temporarily in the nbs/docs folder\n",
     "    \n",
     "    if tmp_doc_path.parent != cfg_path: # move docs folder to root of repo if it doesn't exist there\n",
     "        shutil.rmtree(doc_path, ignore_errors=True)\n",
-    "        shutil.move(tmp_doc_path, cfg_path)"
+    "        shutil.move(tmp_doc_path.as_posix(), cfg_path.as_posix())"
    ]
   },
   {
@@ -514,21 +514,13 @@
     "from nbprocess.doclinks import nbprocess_export\n",
     "nbprocess_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12588a26-43a6-42c4-bacd-896293c871ab",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8 (nbprocess_devt)",
    "language": "python",
-   "name": "python3"
+   "name": "nbdev_devt"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Error was due due to shutil not handling Path objects but needed to be converted to str first.
References  this issue #48 

To test: 
  run nbprocess_quarto in the nbprocess project directory

Expected result: 
  nbprocess_quarto doesn't trigger a traceback and doesn't delete README.md from project directory.