### PR TITLE
wrap showdoc

### DIFF
--- a/nbprocess/showdoc.py
+++ b/nbprocess/showdoc.py
@@ -8,6 +8,7 @@ from fastcore.docments import *
 from fastcore.basics import *
 from fastcore.imports import *
 from fastcore.foundation import *
+from fastcore.meta import delegates
 
 from importlib import import_module
 from .doclinks import *
@@ -15,6 +16,7 @@ import inspect, sys
 from collections import OrderedDict
 from dataclasses import dataclass, is_dataclass
 from .read import get_config
+from textwrap import fill
 
 # %% ../nbs/08_showdoc.ipynb 6
 def _non_empty_keys(d:dict): return L([k for k,v in d.items() if v != inspect._empty])
@@ -115,12 +117,20 @@ def _fmt_sig(sig):
     _params = [str(p[k]).replace(' ','') for k in p.keys() if k != 'self']
     return "(" + ', '.join(_params)  + ")"
 
+def _wrap_sig(s):
+    "wrap a signature to appear on multiple lines if necessary."
+    pad = '> ' + ' ' * 5
+    indent = pad + ' ' * (s.find('(') + 1)
+    return fill(s, width=80, initial_indent=pad, subsequent_indent=indent)
+
 # %% ../nbs/08_showdoc.ipynb 28
 class BasicMarkdownRenderer(ShowDocRenderer):
     def _repr_markdown_(self):
+        if not self.disp: return None
         doc = '---\n\n'
         if self.isfunc: doc += '#'
-        doc += f'### {self.nm}\n\n> **`{self.nm}`**` {_fmt_sig(self.sig)}`'
+        sig = _wrap_sig(f"{self.nm} {_fmt_sig(self.sig)}")
+        doc += f'### {self.nm}\n\n{sig}'
         if self.docs: doc += f"\n\n{self.docs.splitlines()[0]}"
         if self.dm.has_docment: doc += f"\n\n{self.dm}"
         return doc

--- a/nbprocess/showdoc.py
+++ b/nbprocess/showdoc.py
@@ -8,8 +8,6 @@ from fastcore.docments import *
 from fastcore.basics import *
 from fastcore.imports import *
 from fastcore.foundation import *
-from fastcore.meta import delegates
-
 from importlib import import_module
 from .doclinks import *
 import inspect, sys

--- a/nbprocess/showdoc.py
+++ b/nbprocess/showdoc.py
@@ -126,7 +126,6 @@ def _wrap_sig(s):
 # %% ../nbs/08_showdoc.ipynb 28
 class BasicMarkdownRenderer(ShowDocRenderer):
     def _repr_markdown_(self):
-        if not self.disp: return None
         doc = '---\n\n'
         if self.isfunc: doc += '#'
         sig = _wrap_sig(f"{self.nm} {_fmt_sig(self.sig)}")

--- a/nbs/08_showdoc.ipynb
+++ b/nbs/08_showdoc.ipynb
@@ -31,13 +31,15 @@
     "from fastcore.basics import *\n",
     "from fastcore.imports import *\n",
     "from fastcore.foundation import *\n",
+    "from fastcore.meta import delegates\n",
     "\n",
     "from importlib import import_module\n",
     "from nbprocess.doclinks import *\n",
     "import inspect, sys\n",
     "from collections import OrderedDict\n",
     "from dataclasses import dataclass, is_dataclass\n",
-    "from nbprocess.read import get_config"
+    "from nbprocess.read import get_config\n",
+    "from textwrap import fill"
    ]
   },
   {
@@ -222,7 +224,7 @@
        "| **Returns** | **int** |  |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fbe60cf0d30>"
+       "<__main__.DocmentTbl at 0x7f7e788d0cd0>"
       ]
      },
      "execution_count": null,
@@ -284,7 +286,7 @@
        "| c | param c |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fbe60cf00a0>"
+       "<__main__.DocmentTbl at 0x7f7e788d0d90>"
       ]
      },
      "execution_count": null,
@@ -366,7 +368,7 @@
        "| c | str | None |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fbe606605e0>"
+       "<__main__.DocmentTbl at 0x7f7e787e6100>"
       ]
      },
      "execution_count": null,
@@ -401,7 +403,7 @@
        "| d | bool | True | description of param d |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fbe60cdd250>"
+       "<__main__.DocmentTbl at 0x7f7e787e6b50>"
       ]
      },
      "execution_count": null,
@@ -470,18 +472,30 @@
     "def _fmt_sig(sig):\n",
     "    p = sig.parameters\n",
     "    _params = [str(p[k]).replace(' ','') for k in p.keys() if k != 'self']\n",
-    "    return \"(\" + ', '.join(_params)  + \")\""
+    "    return \"(\" + ', '.join(_params)  + \")\"\n",
+    "\n",
+    "def _wrap_sig(s):\n",
+    "    \"wrap a signature to appear on multiple lines if necessary.\"\n",
+    "    pad = '> ' + ' ' * 5\n",
+    "    indent = pad + ' ' * (s.find('(') + 1)\n",
+    "    return fill(s, width=80, initial_indent=pad, subsequent_indent=indent)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "e31c0079-97af-4342-af54-725319d40289",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd1aa1d7-d545-4a76-9de8-394beb4f2b8e",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "<blockquote>\n",
-    "foo bar ding<br>\n",
-    "&nbsp&nbsp&nbsp&nbspbaz\n",
-    "</blockquote>"
+    "#|hide\n",
+    "def _long_f(a_param:int=1, b_param:bool=True, c_param:str='Some value', d:int=2, e:bool=False):\n",
+    "    \"A docstring\"\n",
+    "    ...\n",
+    "    \n",
+    "_res = \">      (a_param:int=1, b_param:bool=True, c_param:str='Somevalue', d:int=2,\\n>       e:bool=False)\"\n",
+    "_sig = _fmt_sig(inspect.signature(_long_f))\n",
+    "test_eq(_wrap_sig(_sig), _res)"
    ]
   },
   {
@@ -494,9 +508,11 @@
     "#|export\n",
     "class BasicMarkdownRenderer(ShowDocRenderer):\n",
     "    def _repr_markdown_(self):\n",
+    "        if not self.disp: return None\n",
     "        doc = '---\\n\\n'\n",
     "        if self.isfunc: doc += '#'\n",
-    "        doc += f'### {self.nm}\\n\\n> **`{self.nm}`**` {_fmt_sig(self.sig)}`'\n",
+    "        sig = _wrap_sig(f\"{self.nm} {_fmt_sig(self.sig)}\")\n",
+    "        doc += f'### {self.nm}\\n\\n{sig}'\n",
     "        if self.docs: doc += f\"\\n\\n{self.docs.splitlines()[0]}\"\n",
     "        if self.dm.has_docment: doc += f\"\\n\\n{self.dm}\"\n",
     "        return doc"
@@ -540,12 +556,12 @@
        "\n",
        "#### f\n",
        "\n",
-       "> **`f`**` (x:int=1)`\n",
+       ">      f (x:int=1)\n",
        "\n",
        "func docstring"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe507cbee0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e788d0250>"
       ]
      },
      "execution_count": null,
@@ -584,7 +600,7 @@
        "\n",
        "#### f\n",
        "\n",
-       "> **`f`**` (x:int=1)`\n",
+       ">      f (x:int=1)\n",
        "\n",
        "func docstring\n",
        "\n",
@@ -594,7 +610,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe60cdd280>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e788edee0>"
       ]
      },
      "execution_count": null,
@@ -634,7 +650,7 @@
        "\n",
        "#### f\n",
        "\n",
-       "> **`f`**` (x=1)`\n",
+       ">      f (x=1)\n",
        "\n",
        "func docstring in the numpy style.\n",
        "\n",
@@ -644,7 +660,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe507cb5e0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e788edc70>"
       ]
      },
      "execution_count": null,
@@ -705,12 +721,12 @@
        "\n",
        "### Foo\n",
        "\n",
-       "> **`Foo`**` (d:str, e:int)`\n",
+       ">      Foo (d:str, e:int)\n",
        "\n",
        "This is the docstring for the __init__ method"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe507de760>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e787e68b0>"
       ]
      },
      "execution_count": null,
@@ -748,7 +764,7 @@
        "\n",
        "#### Foo.a_method\n",
        "\n",
-       "> **`Foo.a_method`**` (a:list, b:dict, c)`\n",
+       ">      Foo.a_method (a:list, b:dict, c)\n",
        "\n",
        "This is a method\n",
        "\n",
@@ -759,7 +775,7 @@
        "| c |  |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe60cdd3d0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e788eddf0>"
       ]
      },
      "execution_count": null,
@@ -823,7 +839,7 @@
        "<blockquote><code>F(x: int = 1)</code></blockquote><p>class docstring</p>"
       ],
       "text/plain": [
-       "<__main__.BasicHtmlRenderer at 0x7fbe3000bd90>"
+       "<__main__.BasicHtmlRenderer at 0x7f7e68398280>"
       ]
      },
      "execution_count": null,
@@ -865,7 +881,7 @@
        "\n",
        "### F.class_method\n",
        "\n",
-       "> **`F.class_method`**` (foo:str, bar:int)`\n",
+       ">      F.class_method (foo:str, bar:int)\n",
        "\n",
        "This is a class method.\n",
        "\n",
@@ -875,7 +891,7 @@
        "| bar | int |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe3000bf70>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e68398bb0>"
       ]
      },
      "execution_count": null,
@@ -915,7 +931,7 @@
        "\n",
        "#### F.regular_method\n",
        "\n",
-       "> **`F.regular_method`**` (baz:bool=True)`\n",
+       ">      F.regular_method (baz:bool=True)\n",
        "\n",
        "This is a regular method\n",
        "\n",
@@ -924,7 +940,7 @@
        "| baz | bool | True | docment for parameter baz |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fbe3000b280>"
+       "<__main__.BasicMarkdownRenderer at 0x7f7e68398400>"
       ]
      },
      "execution_count": null,

--- a/nbs/08_showdoc.ipynb
+++ b/nbs/08_showdoc.ipynb
@@ -224,7 +224,7 @@
        "| **Returns** | **int** |  |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f7e788d0cd0>"
+       "<__main__.DocmentTbl at 0x7f9390160a30>"
       ]
      },
      "execution_count": null,
@@ -286,7 +286,7 @@
        "| c | param c |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f7e788d0d90>"
+       "<__main__.DocmentTbl at 0x7f9390160640>"
       ]
      },
      "execution_count": null,
@@ -368,7 +368,7 @@
        "| c | str | None |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f7e787e6100>"
+       "<__main__.DocmentTbl at 0x7f93b01d1490>"
       ]
      },
      "execution_count": null,
@@ -403,7 +403,7 @@
        "| d | bool | True | description of param d |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f7e787e6b50>"
+       "<__main__.DocmentTbl at 0x7f93b01d1730>"
       ]
      },
      "execution_count": null,
@@ -508,7 +508,6 @@
     "#|export\n",
     "class BasicMarkdownRenderer(ShowDocRenderer):\n",
     "    def _repr_markdown_(self):\n",
-    "        if not self.disp: return None\n",
     "        doc = '---\\n\\n'\n",
     "        if self.isfunc: doc += '#'\n",
     "        sig = _wrap_sig(f\"{self.nm} {_fmt_sig(self.sig)}\")\n",
@@ -561,7 +560,7 @@
        "func docstring"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e788d0250>"
+       "<__main__.BasicMarkdownRenderer at 0x7f9390160550>"
       ]
      },
      "execution_count": null,
@@ -610,7 +609,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e788edee0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f93a063f490>"
       ]
      },
      "execution_count": null,
@@ -660,7 +659,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e788edc70>"
+       "<__main__.BasicMarkdownRenderer at 0x7f93a06298b0>"
       ]
      },
      "execution_count": null,
@@ -726,7 +725,7 @@
        "This is the docstring for the __init__ method"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e787e68b0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f93a0629280>"
       ]
      },
      "execution_count": null,
@@ -775,7 +774,7 @@
        "| c |  |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e788eddf0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f93b01d1400>"
       ]
      },
      "execution_count": null,
@@ -839,7 +838,7 @@
        "<blockquote><code>F(x: int = 1)</code></blockquote><p>class docstring</p>"
       ],
       "text/plain": [
-       "<__main__.BasicHtmlRenderer at 0x7f7e68398280>"
+       "<__main__.BasicHtmlRenderer at 0x7f93902062e0>"
       ]
      },
      "execution_count": null,
@@ -891,7 +890,7 @@
        "| bar | int |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e68398bb0>"
+       "<__main__.BasicMarkdownRenderer at 0x7f93902069a0>"
       ]
      },
      "execution_count": null,
@@ -940,7 +939,7 @@
        "| baz | bool | True | docment for parameter baz |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f7e68398400>"
+       "<__main__.BasicMarkdownRenderer at 0x7f93902063a0>"
       ]
      },
      "execution_count": null,

--- a/nbs/08_showdoc.ipynb
+++ b/nbs/08_showdoc.ipynb
@@ -31,8 +31,6 @@
     "from fastcore.basics import *\n",
     "from fastcore.imports import *\n",
     "from fastcore.foundation import *\n",
-    "from fastcore.meta import delegates\n",
-    "\n",
     "from importlib import import_module\n",
     "from nbprocess.doclinks import *\n",
     "import inspect, sys\n",


### PR DESCRIPTION
Handles long signatures such they wrap onto multiple lines instead of a single line with a horizontal scroll

<img width="702" alt="image" src="https://user-images.githubusercontent.com/1483922/174252729-45ca9316-5161-4eb8-9a45-4d7817ddca53.png">


This closes #67 