### PR TITLE
test `showdoc` edge cases & ignore `typedispatch`

### DIFF
--- a/nbprocess/showdoc.py
+++ b/nbprocess/showdoc.py
@@ -4,6 +4,7 @@
 __all__ = ['DocmentTbl', 'ShowDocRenderer', 'BasicMarkdownRenderer', 'show_doc', 'BasicHtmlRenderer', 'showdoc_nm']
 
 # %% ../nbs/08_showdoc.ipynb 2
+from fastcore.dispatch import TypeDispatch
 from fastcore.docments import *
 from fastcore.basics import *
 from fastcore.imports import *
@@ -139,7 +140,8 @@ def show_doc(sym, disp=True, renderer=None):
     elif isinstance(renderer,str):
         p,m = renderer.rsplit('.', 1)
         renderer = getattr(import_module(p), m)
-    return renderer(sym or show_doc, disp=disp)
+    if isinstance(sym, TypeDispatch): pass
+    else:return renderer(sym or show_doc, disp=disp)
 
 # %% ../nbs/08_showdoc.ipynb 41
 class BasicHtmlRenderer(ShowDocRenderer):

--- a/nbs/08_showdoc.ipynb
+++ b/nbs/08_showdoc.ipynb
@@ -27,6 +27,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
+    "from fastcore.dispatch import TypeDispatch\n",
     "from fastcore.docments import *\n",
     "from fastcore.basics import *\n",
     "from fastcore.imports import *\n",
@@ -43,11 +44,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31282977",
+   "id": "37779036-032f-41cc-bedb-d928f1a25df7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastcore.test import *"
+    "#|hide\n",
+    "from fastcore.test import test_eq"
    ]
   },
   {
@@ -94,6 +96,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
+    "\n",
     "test_eq(_maybe_nm(list), 'list')\n",
     "test_eq(_maybe_nm('fastai'), 'fastai')"
    ]
@@ -222,7 +226,7 @@
        "| **Returns** | **int** |  |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f9390160a30>"
+       "<__main__.DocmentTbl at 0x7fe6392575b0>"
       ]
      },
      "execution_count": null,
@@ -284,7 +288,7 @@
        "| c | param c |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f9390160640>"
+       "<__main__.DocmentTbl at 0x7fe63921d970>"
       ]
      },
      "execution_count": null,
@@ -366,7 +370,7 @@
        "| c | str | None |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f93b01d1490>"
+       "<__main__.DocmentTbl at 0x7fe6385d18b0>"
       ]
      },
      "execution_count": null,
@@ -401,7 +405,7 @@
        "| d | bool | True | description of param d |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7f93b01d1730>"
+       "<__main__.DocmentTbl at 0x7fe639239b20>"
       ]
      },
      "execution_count": null,
@@ -529,7 +533,8 @@
     "    elif isinstance(renderer,str):\n",
     "        p,m = renderer.rsplit('.', 1)\n",
     "        renderer = getattr(import_module(p), m)\n",
-    "    return renderer(sym or show_doc, disp=disp)"
+    "    if isinstance(sym, TypeDispatch): pass\n",
+    "    else:return renderer(sym or show_doc, disp=disp)"
    ]
   },
   {
@@ -558,7 +563,7 @@
        "func docstring"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f9390160550>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe63921d880>"
       ]
      },
      "execution_count": null,
@@ -607,7 +612,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f93a063f490>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe5f8265a60>"
       ]
      },
      "execution_count": null,
@@ -657,7 +662,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f93a06298b0>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe5f82653d0>"
       ]
      },
      "execution_count": null,
@@ -723,7 +728,7 @@
        "This is the docstring for the __init__ method"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f93a0629280>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe5f8265ac0>"
       ]
      },
      "execution_count": null,
@@ -772,7 +777,7 @@
        "| c |  |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f93b01d1400>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe6392422e0>"
       ]
      },
      "execution_count": null,
@@ -836,7 +841,7 @@
        "<blockquote><code>F(x: int = 1)</code></blockquote><p>class docstring</p>"
       ],
       "text/plain": [
-       "<__main__.BasicHtmlRenderer at 0x7f93902062e0>"
+       "<__main__.BasicHtmlRenderer at 0x7fe5f8276280>"
       ]
      },
      "execution_count": null,
@@ -888,7 +893,7 @@
        "| bar | int |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f93902069a0>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe5f8276460>"
       ]
      },
      "execution_count": null,
@@ -937,7 +942,7 @@
        "| baz | bool | True | docment for parameter baz |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7f93902063a0>"
+       "<__main__.BasicMarkdownRenderer at 0x7fe5f8272c70>"
       ]
      },
      "execution_count": null,
@@ -997,6 +1002,70 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac6f8e04-ff14-4978-a4ba-09f7a2b91098",
+   "metadata": {},
+   "source": [
+    "# Test Edgecases -"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bedf2b4d-4ee1-4836-ae91-416ab7c346a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "\n",
+    "######### Test edgecases #############\n",
+    "\n",
+    "######### 1. Enum ####################\n",
+    "e = enum.Enum('e', 'a b')\n",
+    "test_eq(show_doc(e)._repr_markdown_(), '---\\n\\n### e\\n\\n>      e (value, names=None, module=None, qualname=None, type=None, start=1)\\n\\nAn enumeration.')\n",
+    "\n",
+    "######### 2. DataClass ###############\n",
+    "from typing import Sequence\n",
+    "\n",
+    "@dataclass\n",
+    "class A:\n",
+    "    \"Test dataclass\"\n",
+    "    a:int = 2 # First\n",
+    "    b:Sequence[int] = (1,2,3)  # Second\n",
+    "\n",
+    "    def test(self, \n",
+    "        c:int = 1, # it's a test\n",
+    "        d:str = 'test' # it's a second test\n",
+    "    )->str: # it's a return string\n",
+    "        return d\n",
+    "    \n",
+    "test_eq(show_doc(A)._repr_markdown_(), '---\\n\\n### A\\n\\n>      A (a:int=2, b:Sequence[int]=(1,2,3))\\n\\nTest dataclass')\n",
+    "test_eq(show_doc(A.test)._repr_markdown_(),\n",
+    "        \"---\\n\\n#### A.test\\n\\n>      A.test (c:int=1, d:str='test')\\n\\n|    | **Type** | **Default** | **Details** |\\n| -- | -------- | ----------- | ----------- |\\n| c | int | 1 | it's a test |\\n| d | str | test | it's a second test |\\n| **Returns** | **str** |  | **it's a return string** |\")\n",
+    "\n",
+    "######### 3. TypedDispatch ###############\n",
+    "from fastcore.dispatch import typedispatch\n",
+    "\n",
+    "@typedispatch\n",
+    "def _typ_test(\n",
+    "    a:list, # A list\n",
+    "    b:str, # A second integer\n",
+    ") -> float:\n",
+    "    \"Perform op\"\n",
+    "    return a.extend(b)\n",
+    "\n",
+    "@typedispatch\n",
+    "def _typ_test(\n",
+    "    a:str, # An integer\n",
+    "    b:str # A str\n",
+    ") -> float:\n",
+    "    \"Perform op\"\n",
+    "    return str(a) + b\n",
+    "\n",
+    "test_eq(show_doc(_typ_test), None) # show_doc ignores typedispatch at the moment\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ec7a2f01",
    "metadata": {},
    "source": [
@@ -1019,7 +1088,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae7bde11-3a9c-4ff6-a500-0523211e2955",
+   "id": "ee92c8ba-b284-4608-8725-ac6fe21b5d4d",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/nbs/08_showdoc.ipynb
+++ b/nbs/08_showdoc.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "#|hide\n",
-    "from fastcore.test import test_eq"
+    "from fastcore.test import *"
    ]
   },
   {
@@ -226,7 +226,7 @@
        "| **Returns** | **int** |  |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fe6392575b0>"
+       "<__main__.DocmentTbl at 0x7faed87c8070>"
       ]
      },
      "execution_count": null,
@@ -288,7 +288,7 @@
        "| c | param c |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fe63921d970>"
+       "<__main__.DocmentTbl at 0x7faed87a8a60>"
       ]
      },
      "execution_count": null,
@@ -370,7 +370,7 @@
        "| c | str | None |  |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fe6385d18b0>"
+       "<__main__.DocmentTbl at 0x7faed87a8790>"
       ]
      },
      "execution_count": null,
@@ -405,7 +405,7 @@
        "| d | bool | True | description of param d |"
       ],
       "text/plain": [
-       "<__main__.DocmentTbl at 0x7fe639239b20>"
+       "<__main__.DocmentTbl at 0x7faed87b33d0>"
       ]
      },
      "execution_count": null,
@@ -563,7 +563,7 @@
        "func docstring"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe63921d880>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87bb700>"
       ]
      },
      "execution_count": null,
@@ -612,7 +612,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe5f8265a60>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87aaa90>"
       ]
      },
      "execution_count": null,
@@ -662,7 +662,7 @@
        "| **Returns** | **None** |  | **this function doesn't return anything** |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe5f82653d0>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87aa790>"
       ]
      },
      "execution_count": null,
@@ -728,7 +728,7 @@
        "This is the docstring for the __init__ method"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe5f8265ac0>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87b3040>"
       ]
      },
      "execution_count": null,
@@ -777,7 +777,7 @@
        "| c |  |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe6392422e0>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87aa0a0>"
       ]
      },
      "execution_count": null,
@@ -841,7 +841,7 @@
        "<blockquote><code>F(x: int = 1)</code></blockquote><p>class docstring</p>"
       ],
       "text/plain": [
-       "<__main__.BasicHtmlRenderer at 0x7fe5f8276280>"
+       "<__main__.BasicHtmlRenderer at 0x7faed87b9f40>"
       ]
      },
      "execution_count": null,
@@ -893,7 +893,7 @@
        "| bar | int |  |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe5f8276460>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87b9640>"
       ]
      },
      "execution_count": null,
@@ -942,7 +942,7 @@
        "| baz | bool | True | docment for parameter baz |"
       ],
       "text/plain": [
-       "<__main__.BasicMarkdownRenderer at 0x7fe5f8272c70>"
+       "<__main__.BasicMarkdownRenderer at 0x7faed87b9970>"
       ]
      },
      "execution_count": null,


### PR DESCRIPTION
This PR does two things:

1.  Adds tests for `showdoc` edgecases I found in nbdev, the rest of the edge cases I display in the notebook itself.  
2. I noticed that we are currently ignoring `typedispatch` in for showdoc in nbdev v1.  We should discuss how we want to display typed dispatch in the docs as that is an interesting use case.  For right now, I will ignore `typedispatch` so the docs won't break when you try to convert to nbprocess.

Note: I had already addressed other edge cases in previous PRs


cc: @jph00 @muellerzr 

This closes #62 