### PR TITLE
Conditionally load modules for doclinks

### DIFF
--- a/nbprocess/doclinks.py
+++ b/nbprocess/doclinks.py
@@ -158,6 +158,12 @@ def _settings_libs():
     except FileNotFoundError: return 'nbprocess'
 
 # %% ../nbs/04b_doclinks.ipynb 31
+def _cond_load(o): 
+    try: o.load() 
+    except: return False
+    return True
+
+# %% ../nbs/04b_doclinks.ipynb 32
 class NbdevLookup:
     "Mapping from symbol names to URLs with docs"
     def __init__(self, strip_libs=None, incl_libs=None, skip_mods=None):
@@ -167,7 +173,7 @@ class NbdevLookup:
         if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()
         # Dict from lib name to _nbprocess module for incl_libs (defaults to all)
         self.entries = {o.name: o.load() for o in pkg_resources.iter_entry_points(group='nbdev')
-                       if incl_libs is None or o.dist.key in incl_libs}
+                       if _cond_load(o) and (incl_libs is None or o.dist.key in incl_libs)}
         py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())
         for m in strip_libs:
             if m in self.entries:
@@ -180,7 +186,7 @@ class NbdevLookup:
 
     def __getitem__(self, s): return self.syms.get(s, None)
 
-# %% ../nbs/04b_doclinks.ipynb 39
+# %% ../nbs/04b_doclinks.ipynb 40
 @patch
 def _link_sym(self:NbdevLookup, m):
     l = m.group(1)

--- a/nbprocess/doclinks.py
+++ b/nbprocess/doclinks.py
@@ -158,7 +158,8 @@ def _settings_libs():
     except FileNotFoundError: return 'nbprocess'
 
 # %% ../nbs/04b_doclinks.ipynb 31
-def _cond_load(o): 
+def _if_loads(o):
+    "Determine of a module can load."
     try: o.load() 
     except: return False
     return True
@@ -173,7 +174,7 @@ class NbdevLookup:
         if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()
         # Dict from lib name to _nbprocess module for incl_libs (defaults to all)
         self.entries = {o.name: o.load() for o in pkg_resources.iter_entry_points(group='nbdev')
-                       if _cond_load(o) and (incl_libs is None or o.dist.key in incl_libs)}
+                       if _if_loads(o) and (incl_libs is None or o.dist.key in incl_libs)}
         py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())
         for m in strip_libs:
             if m in self.entries:

--- a/nbs/04b_doclinks.ipynb
+++ b/nbs/04b_doclinks.ipynb
@@ -473,6 +473,20 @@
    "outputs": [],
    "source": [
     "#|export\n",
+    "def _if_loads(o):\n",
+    "    \"Determine of a module can load.\"\n",
+    "    try: o.load() \n",
+    "    except: return False\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|export\n",
     "class NbdevLookup:\n",
     "    \"Mapping from symbol names to URLs with docs\"\n",
     "    def __init__(self, strip_libs=None, incl_libs=None, skip_mods=None):\n",
@@ -482,7 +496,7 @@
     "        if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()\n",
     "        # Dict from lib name to _nbprocess module for incl_libs (defaults to all)\n",
     "        self.entries = {o.name: o.load() for o in pkg_resources.iter_entry_points(group='nbdev')\n",
-    "                       if incl_libs is None or o.dist.key in incl_libs}\n",
+    "                       if _if_loads(o) and (incl_libs is None or o.dist.key in incl_libs)}\n",
     "        py_syms = merge(*L(o['syms'].values() for o in self.entries.values()).concat())\n",
     "        for m in strip_libs:\n",
     "            if m in self.entries:\n",


### PR DESCRIPTION
We try to install modules no matter what in CI.  This causes issues for nbdev sites that are documentation only, since we prospectively install everything and there is a setup.py.  This change only makes sure packages that can be loaded successfully are used.

This closes #110 