### PR TITLE
escape backslash in backtick symbol matching

### DIFF
--- a/nbprocess/doclinks.py
+++ b/nbprocess/doclinks.py
@@ -186,6 +186,7 @@ def _link_sym(self:NbdevLookup, m):
     l = m.group(1)
     s = self[l]
     if s is None: return m.group(0)
+    if l == "\\": return rf"[\{l}]({s})"
     return rf"[{l}]({s})"
 
 _re_backticks = re.compile(r'`([^`\s]+)`')

--- a/nbs/04b_doclinks.ipynb
+++ b/nbs/04b_doclinks.ipynb
@@ -572,6 +572,7 @@
     "    l = m.group(1)\n",
     "    s = self[l]\n",
     "    if s is None: return m.group(0)\n",
+    "    if l == \"\\\\\": return rf\"[\\{l}]({s})\"\n",
     "    return rf\"[{l}]({s})\"\n",
     "\n",
     "_re_backticks = re.compile(r'`([^`\\s]+)`')\n",
@@ -638,6 +639,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "this is a link to [+](https://help.dyalog.com/18.2/index.htm#Language/Symbols/Plus%20Sign.htm) (Zilde) and this is a link to [\\\\](https://help.dyalog.com/18.2/index.htm#Language/Symbols/Slope.htm) (Slope)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#|eval: false\n",
+    "c = NbdevLookup('nbprocess')\n",
+    "Markdown(c.linkify(\"this is a link to `+` (Zilde) and this is a link to `\\` (Slope)\"))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -670,7 +696,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.7 ('base')",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
This fixes [the backslash issue in the APL study](https://github.com/fastai/apl-study/issues/9). 

It's a bit hacky as I said in the issue, if someone has a better idea please let me know.